### PR TITLE
fix url after modal close

### DIFF
--- a/src/main/resources/static/js/main-table.js
+++ b/src/main/resources/static/js/main-table.js
@@ -1590,6 +1590,7 @@ $(function () {
         $('.remove-history').remove();
         $('.upload-more-history').removeAttr('data-clientid');
         $('.upload-more-history').attr("data-page", 1);
+        backUrl();
     });
 });
 


### PR DESCRIPTION
Если открыть карточку клиента, потом закрыть ее не крестиком, а кликом по внешней области, в строке УРЛ сохраняется адрес карточки. Если после перейти на любую страницу, а потом "назад" попадаешь в открытую карточку клиента, а не на доску.